### PR TITLE
Handle null values

### DIFF
--- a/flaco/includes.pxd
+++ b/flaco/includes.pxd
@@ -9,12 +9,13 @@ cdef extern from "./libflaco.h":
         Float32
         Float64
         String
+        Null
 
     ctypedef struct Int32_Body:
-        np.int32_t _0
+        const np.int32_t _0
 
     ctypedef struct Int64_Body:
-        np.int64_t _0
+        const np.int64_t _0
 
     ctypedef struct Float32_Body:
         np.float32_t _0

--- a/flaco/io.pyx
+++ b/flaco/io.pyx
@@ -1,3 +1,5 @@
+import pandas as pd
+cimport cython
 cimport numpy as np
 import numpy as np
 from libc.stdlib cimport malloc, free
@@ -10,7 +12,7 @@ np.import_array()
 cpdef tuple read_sql(str stmt, Engine engine):
     cdef bytes stmt_bytes = stmt.encode("utf-8")
     cdef lib.RowIteratorPtr row_iterator
-    cdef lib.RowPtr row
+    cdef lib.RowPtr row_ptr
     cdef lib.RowColumnNamesArrayPtr row_col_names
     cdef lib.RowTypesArrayPtr row_types
     cdef lib.RowDataArrayPtr row_data_ptr
@@ -20,24 +22,18 @@ cpdef tuple read_sql(str stmt, Engine engine):
     row_iterator = lib.read_sql(<char*>stmt_bytes, engine.client_ptr)
 
     # Read first row
-    row = lib.next_row(row_iterator)
+    row_ptr = lib.next_row(row_iterator)
 
     # get column names and types
-    row_types = lib.row_types(row)
-    row_col_names = lib.row_column_names(row)
-    n_columns = lib.n_columns(row)
+    row_types = lib.row_types(row_ptr)
+    row_col_names = lib.row_column_names(row_ptr)
+    n_columns = lib.n_columns(row_ptr)
 
     # build columns
     columns = np.zeros(shape=n_columns, dtype=object)
     cdef int i
     for i in range(0, n_columns):
-        print(row_col_names[i])
         columns[i] = row_col_names[i].decode()
-    print(f"Done, columns: {columns}")
-
-    # build arrays based on types
-    for i in range(0, n_columns):
-        print(row_types[i])
 
     # np.ndarray would force all internal arrays to be object dtypes
     # b/c each array has a different dtype.
@@ -46,12 +42,12 @@ cpdef tuple read_sql(str stmt, Engine engine):
     # Begin looping until no rows are returned
     cdef int row_idx = 0
     while True:
-        if row == NULL:
+        if row_ptr == NULL:
             break
         else:
 
             # Insert new row
-            row_data_ptr = lib.row_data(row, row_types)
+            row_data_ptr = lib.row_data(row_ptr, row_types)
 
             if row_idx == 0:
                 # Initialize arrays for output
@@ -62,29 +58,38 @@ cpdef tuple read_sql(str stmt, Engine engine):
             # grow arrays if next insert is passed current len
             if output[0].shape[0] < row_idx:
                 for i in range(0, n_columns):
-                    resize(output[i], output[0].shape[0] + 100)
+                    resize(output[i], output[0].shape[0] + 1000)
 
             for i in range(0, n_columns):
                 data = lib.index_row(row_data_ptr, i)
                 if data.tag == lib.Data_Tag.Int64:
                     output[i][row_idx] = data.int64._0
+
                 elif data.tag == lib.Data_Tag.Int32:
                     output[i][row_idx] = data.int32._0
+
                 elif data.tag == lib.Data_Tag.Float64:
                     output[i][row_idx] = data.float64._0
+
                 elif data.tag == lib.Data_Tag.Float32:
                     output[i][row_idx] = data.float32._0
+
                 elif data.tag == lib.Data_Tag.String:
-                    output[i][row_idx] = data.string._0
+                    if data.string._0 == NULL:
+                        output[i][row_idx] = None
+                    else:
+                        output[i][row_idx] = data.string._0
+                elif data.tag == lib.Data_Tag.Null:
+                    output[i][row_idx] = None
+
             row_idx += 1
 
-        row = lib.next_row(row_iterator)
+        row_ptr = lib.next_row(row_iterator)
 
     # Ensure arrays are correct size
     if output[0].shape[0] != row_idx:
         for i in range(0, n_columns):
             resize(output[i], row_idx)
-
     return columns, output
 
 cdef resize(np.ndarray array, int len):
@@ -93,9 +98,9 @@ cdef resize(np.ndarray array, int len):
 cdef np.ndarray array_init(lib.Data data, int len):
     cdef np.ndarray array
     if data.tag == lib.Data_Tag.Int32:
-        array = np.empty(shape=len, dtype=np.int32)
+        array = np.empty(shape=len, dtype=object)
     elif data.tag == lib.Data_Tag.Int64:
-        array = np.empty(shape=len, dtype=np.int64)
+        array = np.empty(shape=len, dtype=object)
     elif data.tag == lib.Data_Tag.Float32:
         array = np.empty(shape=len, dtype=np.float32)
     elif data.tag == lib.Data_Tag.Float64:


### PR DESCRIPTION
Requires using numpy.array(..., dtype=object) b/c only `pandas.array` supports nullable integers, but cannot be resized.