### PR TITLE
Use numpy.datetime64 dtypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "bumpalo",
  "cbindgen",
  "postgres",
+ "postgres-protocol",
  "rust_decimal",
  "serde_json",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +159,7 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 name = "flaco"
 version = "0.4.2"
 dependencies = [
+ "bumpalo",
  "cbindgen",
  "postgres",
  "rust_decimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Unlicense/MIT"
 crate-type = ["staticlib"]
 
 [dependencies]
+bumpalo      = "3.8.0"
 uuid         = "0.8.2"
 serde_json   = "1.0.68"
 rust_decimal = { version = "1.16.0", features = ["db-postgres"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde_json   = "1.0.68"
 rust_decimal = { version = "1.16.0", features = ["db-postgres"] }
 time         = { version = "0.3.3",  features = ["formatting"] }
 postgres     = { version = "0.19.1", features = ["with-serde_json-1", "with-time-0_3", "with-uuid-0_8"] }
+postgres-protocol = "0.6.2"
 
 [build-dependencies]
 cbindgen = "^0.6.0"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![PyPI - Wheel](https://img.shields.io/pypi/wheel/flaco)
 [![Downloads](https://pepy.tech/badge/flaco/month)](https://pepy.tech/project/flaco)
 
-Perhaps the fastest and most memory efficient way to
+Perhaps the fastest* and most memory efficient way to
 pull data from PostgreSQL into [pandas](https://pandas.pydata.org/) 
 and [numpy](https://numpy.org/doc/stable/index.html). 🚀
 
@@ -18,24 +18,25 @@ and about ~2-3x faster. However, it's probably 50x less stable at the moment. �
 To whet your appetite, here's a memory profile between flaco, [connectorx](https://github.com/sfu-db/connector-x) 
 and `pandas.read_sql` on a table with 1M rows with columns of various types. 
 (see [test_benchmarks.py](benchmarks/test_benchmarks.py)) *If the data, 
-specifically integer types, has null values, you can expect a bit lower savings than the ~4x 
-you see here; therefore (hot tip 🔥), supply fill values in your queries where possible via `coalesce`.
+specifically integer types, has null values, you can expect a bit lower savings
+what you see here; therefore (hot tip 🔥), supply fill values in your queries 
+where possible via `coalesce`.
 
 ```bash
 Line #    Mem usage    Increment  Occurences   Line Contents
 ============================================================
-   118     98.0 MiB     98.0 MiB           1   @profile
+   118     97.9 MiB     97.9 MiB           1   @profile
    119                                         def memory_profile():
-   120     98.0 MiB      0.0 MiB           1       stmt = "select * from test_table"
+   120     97.9 MiB      0.0 MiB           1       stmt = "select * from test_table"
    121                                         
-   122    359.9 MiB    261.9 MiB           1       _cx_df = cx.read_sql(DB_URI, stmt, return_type="pandas")
+   122    354.9 MiB    257.0 MiB           1       _cx_df = cx.read_sql(DB_URI, stmt, return_type="pandas")
    123                                         
-   124    359.9 MiB      0.0 MiB           1       with Database(DB_URI) as con:
-   125    545.4 MiB    185.4 MiB           1           data = read_sql(stmt, con)
-   126    553.5 MiB      8.2 MiB           1           _flaco_df = pd.DataFrame(data, copy=False)
+   124    354.9 MiB      0.0 MiB           1       with Database(DB_URI) as con:
+   125    533.9 MiB    178.9 MiB           1           data = read_sql(stmt, con)
+   126    541.2 MiB      7.3 MiB           1           _flaco_df = pd.DataFrame(data, copy=False)
    127                                         
-   128    557.8 MiB      4.3 MiB           1       engine = create_engine(DB_URI)
-   129   1681.0 MiB   1123.2 MiB           1       _pandas_df = pd.read_sql(stmt, engine)
+   128    545.3 MiB      4.1 MiB           1       engine = create_engine(DB_URI)
+   129   1680.9 MiB   1135.5 MiB           1       _pandas_df = pd.read_sql(stmt, engine)
 ```
 
 ---
@@ -87,7 +88,8 @@ They have much wider support for a range of data sources, while flaco only
 supports postgres for now.
 
 Performance wise, benchmarking seems to indicate flaco is generally more performant
-in terms of memory, but connectorx is faster.
+in terms of memory, but connectorx is faster when temporal data types (time, timestamp, etc)
+are used. If it's pure numeric dtypes, flaco is faster and more memory efficient.
 
 Connectorx [will make precheck queries](https://github.com/sfu-db/connector-x#how-does-connectorx-download-the-data)
 to the source before starting to download data. Depending on your application,
@@ -99,8 +101,8 @@ Flaco will not run _any_ precheck queries. _However_, you can supply either
 `n_rows` or `size_hint` to `flaco.io.read_sql` to give either exact, or a
 hint to reduce the number of allocations/resizing of arrays during data loading.
 
-When in doubt, it's likely you should choose connectorx as it's more mature and
-offers great performance.
+**When in doubt, it's likely you should choose connectorx as it's more mature and
+offers great performance.**
 
 # Words of caution
 

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -127,6 +127,7 @@ def memory_profile():
 
     engine = create_engine(DB_URI)
     _pandas_df = pd.read_sql(stmt, engine)
+    breakpoint()
 
 
 if __name__ == "__main__":

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -117,17 +117,16 @@ def _table_setup(n_rows: int = 1_000_000, include_nulls: bool = False):
 
 @profile
 def memory_profile():
-    stmt = "select col1, col2, col3, col4, col5, col6 from test_table"
+    stmt = "select * from test_table"
 
     _cx_df = cx.read_sql(DB_URI, stmt, return_type="pandas")
 
     with Database(DB_URI) as con:
-        data = read_sql(stmt, con, n_rows=1_000_000)
+        data = read_sql(stmt, con)
         _flaco_df = pd.DataFrame(data, copy=False)
 
     engine = create_engine(DB_URI)
     _pandas_df = pd.read_sql(stmt, engine)
-    #breakpoint()
 
 
 if __name__ == "__main__":

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -131,4 +131,9 @@ def memory_profile():
 
 if __name__ == "__main__":
     #_table_setup(n_rows=1_000_000, include_nulls=False)
-    memory_profile()
+    stmt = "select * from test_table"
+
+    with Database(DB_URI) as con:
+        data = read_sql(stmt, con)
+        _flaco_df = pd.DataFrame(data, copy=False)
+    #memory_profile()

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -127,13 +127,8 @@ def memory_profile():
 
     engine = create_engine(DB_URI)
     _pandas_df = pd.read_sql(stmt, engine)
-    breakpoint()
 
 
 if __name__ == "__main__":
-    #_table_setup(n_rows=1_000_000, include_nulls=False)
-    #stmt = "select * from test_table"
-    #with Database(DB_URI) as con:
-    #    data = read_sql(stmt, con)
-    #    _flaco_df = pd.DataFrame(data, copy=False)
+    _table_setup(n_rows=1_000_000, include_nulls=False)
     memory_profile()

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -131,9 +131,8 @@ def memory_profile():
 
 if __name__ == "__main__":
     #_table_setup(n_rows=1_000_000, include_nulls=False)
-    stmt = "select * from test_table"
-
-    with Database(DB_URI) as con:
-        data = read_sql(stmt, con)
-        _flaco_df = pd.DataFrame(data, copy=False)
-    #memory_profile()
+    #stmt = "select * from test_table"
+    #with Database(DB_URI) as con:
+    #    data = read_sql(stmt, con)
+    #    _flaco_df = pd.DataFrame(data, copy=False)
+    memory_profile()

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -117,7 +117,7 @@ def _table_setup(n_rows: int = 1_000_000, include_nulls: bool = False):
 
 @profile
 def memory_profile():
-    stmt = "select * from test_table"
+    stmt = "select col1, col2, col3, col4, col5, col6 from test_table"
 
     _cx_df = cx.read_sql(DB_URI, stmt, return_type="pandas")
 

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -127,7 +127,7 @@ def memory_profile():
 
     engine = create_engine(DB_URI)
     _pandas_df = pd.read_sql(stmt, engine)
-    breakpoint()
+    #breakpoint()
 
 
 if __name__ == "__main__":

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -127,8 +127,9 @@ def memory_profile():
 
     engine = create_engine(DB_URI)
     _pandas_df = pd.read_sql(stmt, engine)
+    breakpoint()
 
 
 if __name__ == "__main__":
-    _table_setup(n_rows=1_000_000, include_nulls=False)
+    #_table_setup(n_rows=1_000_000, include_nulls=False)
     memory_profile()

--- a/flaco/flaco.h
+++ b/flaco/flaco.h
@@ -17,10 +17,18 @@ typedef struct {
 } BytesPtr;
 
 typedef struct {
-  int32_t year;
-  uint8_t month;
-  uint8_t day;
+  /**
+   * The value represents the number of days since January 1st, 2000.
+   */
+  int32_t offset;
 } DateInfo;
+
+typedef struct {
+  /**
+   * The value represents the number of microseconds since midnight, January 1st, 2000.
+   */
+  int64_t offset;
+} DateTimeInfo;
 
 typedef struct {
   uint8_t hour;
@@ -28,24 +36,6 @@ typedef struct {
   uint8_t second;
   uint32_t usecond;
 } TimeInfo;
-
-typedef struct {
-  DateInfo date;
-  TimeInfo time;
-} DateTimeInfo;
-
-typedef struct {
-  int8_t hours;
-  int8_t minutes;
-  int8_t seconds;
-  bool is_positive;
-} TzInfo;
-
-typedef struct {
-  DateInfo date;
-  TimeInfo time;
-  TzInfo tz;
-} DateTimeTzInfo;
 
 typedef struct {
   char *ptr;
@@ -56,7 +46,6 @@ typedef enum {
   Bytes,
   Date,
   DateTime,
-  DateTimeTz,
   Time,
   Boolean,
   Decimal,
@@ -82,10 +71,6 @@ typedef struct {
 typedef struct {
   DateTimeInfo *_0;
 } DateTime_Body;
-
-typedef struct {
-  DateTimeTzInfo *_0;
-} DateTimeTz_Body;
 
 typedef struct {
   TimeInfo *_0;
@@ -137,7 +122,6 @@ typedef struct {
     Bytes_Body bytes;
     Date_Body date;
     DateTime_Body date_time;
-    DateTimeTz_Body date_time_tz;
     Time_Body time;
     Boolean_Body boolean;
     Decimal_Body decimal;

--- a/flaco/flaco.h
+++ b/flaco/flaco.h
@@ -9,6 +9,8 @@ typedef uint32_t *DatabasePtr;
 
 typedef char *Exception;
 
+typedef uint32_t *SessionPtr;
+
 typedef struct {
   uint8_t *ptr;
   uint32_t len;
@@ -70,63 +72,63 @@ typedef enum {
 } Data_Tag;
 
 typedef struct {
-  BytesPtr _0;
+  BytesPtr *_0;
 } Bytes_Body;
 
 typedef struct {
-  DateInfo _0;
+  DateInfo *_0;
 } Date_Body;
 
 typedef struct {
-  DateTimeInfo _0;
+  DateTimeInfo *_0;
 } DateTime_Body;
 
 typedef struct {
-  DateTimeTzInfo _0;
+  DateTimeTzInfo *_0;
 } DateTimeTz_Body;
 
 typedef struct {
-  TimeInfo _0;
+  TimeInfo *_0;
 } Time_Body;
 
 typedef struct {
-  bool _0;
+  bool *_0;
 } Boolean_Body;
 
 typedef struct {
-  double _0;
+  double *_0;
 } Decimal_Body;
 
 typedef struct {
-  int8_t _0;
+  int8_t *_0;
 } Int8_Body;
 
 typedef struct {
-  int16_t _0;
+  int16_t *_0;
 } Int16_Body;
 
 typedef struct {
-  int32_t _0;
+  int32_t *_0;
 } Int32_Body;
 
 typedef struct {
-  uint32_t _0;
+  uint32_t *_0;
 } Uint32_Body;
 
 typedef struct {
-  int64_t _0;
+  int64_t *_0;
 } Int64_Body;
 
 typedef struct {
-  float _0;
+  float *_0;
 } Float32_Body;
 
 typedef struct {
-  double _0;
+  double *_0;
 } Float64_Body;
 
 typedef struct {
-  StringPtr _0;
+  StringPtr *_0;
 } String_Body;
 
 typedef struct {
@@ -164,12 +166,17 @@ void db_disconnect(DatabasePtr ptr);
 
 void free_db(DatabasePtr ptr);
 
+void free_session(SessionPtr session);
+
 Data *index_row(RowDataArrayPtr row_data_array_ptr, uint32_t len, uint32_t idx);
+
+SessionPtr init_session(void);
 
 void next_row(RowIteratorPtr *row_iter_ptr,
               RowDataArrayPtr *row_data_array_ptr,
               uint32_t *n_columns,
               RowColumnNamesArrayPtr *column_names,
+              SessionPtr *session,
               Exception *exc);
 
 RowIteratorPtr read_sql(const char *stmt_ptr, DatabasePtr db_ptr, Exception *exc);

--- a/flaco/flaco.h
+++ b/flaco/flaco.h
@@ -9,8 +9,6 @@ typedef uint32_t *DatabasePtr;
 
 typedef char *Exception;
 
-typedef uint32_t *SessionPtr;
-
 typedef struct {
   uint8_t *ptr;
   uint32_t len;
@@ -61,59 +59,59 @@ typedef enum {
 } Data_Tag;
 
 typedef struct {
-  BytesPtr *_0;
+  BytesPtr _0;
 } Bytes_Body;
 
 typedef struct {
-  DateInfo *_0;
+  DateInfo _0;
 } Date_Body;
 
 typedef struct {
-  DateTimeInfo *_0;
+  DateTimeInfo _0;
 } DateTime_Body;
 
 typedef struct {
-  TimeInfo *_0;
+  TimeInfo _0;
 } Time_Body;
 
 typedef struct {
-  bool *_0;
+  bool _0;
 } Boolean_Body;
 
 typedef struct {
-  double *_0;
+  double _0;
 } Decimal_Body;
 
 typedef struct {
-  int8_t *_0;
+  int8_t _0;
 } Int8_Body;
 
 typedef struct {
-  int16_t *_0;
+  int16_t _0;
 } Int16_Body;
 
 typedef struct {
-  int32_t *_0;
+  int32_t _0;
 } Int32_Body;
 
 typedef struct {
-  uint32_t *_0;
+  uint32_t _0;
 } Uint32_Body;
 
 typedef struct {
-  int64_t *_0;
+  int64_t _0;
 } Int64_Body;
 
 typedef struct {
-  float *_0;
+  float _0;
 } Float32_Body;
 
 typedef struct {
-  double *_0;
+  double _0;
 } Float64_Body;
 
 typedef struct {
-  StringPtr *_0;
+  StringPtr _0;
 } String_Body;
 
 typedef struct {
@@ -150,17 +148,12 @@ void db_disconnect(DatabasePtr ptr);
 
 void free_db(DatabasePtr ptr);
 
-void free_session(SessionPtr session);
-
 Data *index_row(RowDataArrayPtr row_data_array_ptr, uint32_t len, uint32_t idx);
-
-SessionPtr init_session(void);
 
 void next_row(RowIteratorPtr *row_iter_ptr,
               RowDataArrayPtr *row_data_array_ptr,
               uint32_t *n_columns,
               RowColumnNamesArrayPtr *column_names,
-              SessionPtr *session,
               Exception *exc);
 
 RowIteratorPtr read_sql(const char *stmt_ptr, DatabasePtr db_ptr, Exception *exc);

--- a/flaco/includes.pxd
+++ b/flaco/includes.pxd
@@ -47,46 +47,46 @@ cdef extern from "./flaco.h":
     ctypedef char *Exception;
 
     ctypedef struct Bytes_Body:
-        BytesPtr *_0
+        BytesPtr _0
 
     ctypedef struct Boolean_Body:
-        bool *_0
+        bool _0
 
     ctypedef struct Date_Body:
-        DateInfo *_0
+        DateInfo _0
 
     ctypedef struct DateTime_Body:
-        DateTimeInfo *_0
+        DateTimeInfo _0
 
     ctypedef struct Time_Body:
-        TimeInfo *_0
+        TimeInfo _0
 
     ctypedef struct Decimal_Body:
-        np.float64_t *_0
+        np.float64_t _0
 
     ctypedef struct Int8_Body:
-        np.int8_t *_0
+        np.int8_t _0
 
     ctypedef struct Int16_Body:
-        np.int16_t *_0
+        np.int16_t _0
 
     ctypedef struct Uint32_Body:
-        np.uint32_t *_0
+        np.uint32_t _0
 
     ctypedef struct Int32_Body:
-        np.int32_t *_0
+        np.int32_t _0
 
     ctypedef struct Int64_Body:
-        np.int64_t *_0
+        np.int64_t _0
 
     ctypedef struct Float32_Body:
-        np.float32_t *_0
+        np.float32_t _0
 
     ctypedef struct Float64_Body:
-        np.float64_t *_0
+        np.float64_t _0
 
     ctypedef struct String_Body:
-        StringPtr *_0
+        StringPtr _0
 
     ctypedef struct Data:
         Data_Tag tag
@@ -115,8 +115,7 @@ cdef extern from "./flaco.h":
     DatabasePtr db_create(char *uri_ptr)
     void db_connect(DatabasePtr ptr, Exception *exc)
     void db_disconnect(DatabasePtr ptr)
-    SessionPtr init_session()
-    void free_session(SessionPtr session)
+
     RowIteratorPtr read_sql(const char *stmt_ptr, DatabasePtr db_ptr, Exception *exc)
 
     void free_db(DatabasePtr ptr)
@@ -126,7 +125,6 @@ cdef extern from "./flaco.h":
             RowDataArrayPtr *row_ptr,
             np.uint32_t *n_columns,
             RowColumnNamesArrayPtr *column_names,
-            SessionPtr *session,
             Exception *exc
     )
 

--- a/flaco/includes.pxd
+++ b/flaco/includes.pxd
@@ -62,49 +62,49 @@ cdef extern from "./flaco.h":
     ctypedef char *Exception;
 
     ctypedef struct Bytes_Body:
-        BytesPtr _0
+        BytesPtr *_0
 
     ctypedef struct Boolean_Body:
-        bool _0
+        bool *_0
 
     ctypedef struct Date_Body:
-        DateInfo _0
+        DateInfo *_0
 
     ctypedef struct DateTime_Body:
-        DateTimeInfo _0
+        DateTimeInfo *_0
 
     ctypedef struct DateTimeTz_Body:
-        DateTimeTzInfo _0
+        DateTimeTzInfo *_0
 
     ctypedef struct Time_Body:
-        TimeInfo _0
+        TimeInfo *_0
 
     ctypedef struct Decimal_Body:
-        np.float64_t _0
+        np.float64_t *_0
 
     ctypedef struct Int8_Body:
-        np.int8_t _0
+        np.int8_t *_0
 
     ctypedef struct Int16_Body:
-        np.int16_t _0
+        np.int16_t *_0
 
     ctypedef struct Uint32_Body:
-        np.uint32_t _0
+        np.uint32_t *_0
 
     ctypedef struct Int32_Body:
-        np.int32_t _0
+        np.int32_t *_0
 
     ctypedef struct Int64_Body:
-        np.int64_t _0
+        np.int64_t *_0
 
     ctypedef struct Float32_Body:
-        np.float32_t _0
+        np.float32_t *_0
 
     ctypedef struct Float64_Body:
-        np.float64_t _0
+        np.float64_t *_0
 
     ctypedef struct String_Body:
-        StringPtr _0
+        StringPtr *_0
 
     ctypedef struct Data:
         Data_Tag tag
@@ -129,11 +129,13 @@ cdef extern from "./flaco.h":
     ctypedef np.uint32_t *RowIteratorPtr
     ctypedef char **RowColumnNamesArrayPtr
     ctypedef np.uint32_t *RowDataArrayPtr
+    ctypedef np.uint32_t *SessionPtr
 
     DatabasePtr db_create(char *uri_ptr)
     void db_connect(DatabasePtr ptr, Exception *exc)
     void db_disconnect(DatabasePtr ptr)
-
+    SessionPtr init_session()
+    void free_session(SessionPtr session)
     RowIteratorPtr read_sql(const char *stmt_ptr, DatabasePtr db_ptr, Exception *exc)
 
     void free_db(DatabasePtr ptr)
@@ -143,6 +145,7 @@ cdef extern from "./flaco.h":
             RowDataArrayPtr *row_ptr,
             np.uint32_t *n_columns,
             RowColumnNamesArrayPtr *column_names,
+            SessionPtr *session,
             Exception *exc
     )
 

--- a/flaco/includes.pxd
+++ b/flaco/includes.pxd
@@ -16,9 +16,7 @@ cdef extern from "./flaco.h":
         np.uint32_t len
 
     ctypedef struct DateInfo:
-        np.int8_t year
-        np.uint8_t month
-        np.uint8_t day
+        np.int32_t offset
 
     ctypedef struct TimeInfo:
         np.uint8_t hour
@@ -27,26 +25,13 @@ cdef extern from "./flaco.h":
         np.uint32_t usecond
 
     ctypedef struct DateTimeInfo:
-        DateInfo date
-        TimeInfo time
-
-    ctypedef struct TzInfo:
-        np.int8_t hours
-        np.int8_t minutes
-        np.int8_t seconds
-        bool is_positive
-
-    ctypedef struct DateTimeTzInfo:
-        DateInfo date
-        TimeInfo time
-        TzInfo tz
+        np.int64_t offset
 
     ctypedef enum Data_Tag:
         Bytes
         Boolean
         Date
         DateTime
-        DateTimeTz
         Time
         Decimal
         Int8
@@ -72,9 +57,6 @@ cdef extern from "./flaco.h":
 
     ctypedef struct DateTime_Body:
         DateTimeInfo *_0
-
-    ctypedef struct DateTimeTz_Body:
-        DateTimeTzInfo *_0
 
     ctypedef struct Time_Body:
         TimeInfo *_0
@@ -113,7 +95,6 @@ cdef extern from "./flaco.h":
         Boolean_Body boolean
         Date_Body date
         DateTime_Body date_time
-        DateTimeTz_Body date_time_tz
         Time_Body time
         Decimal_Body decimal
         Int8_Body int8

--- a/flaco/io.pyx
+++ b/flaco/io.pyx
@@ -29,7 +29,6 @@ cpdef dict read_sql(str stmt, Database db, int n_rows=-1, int size_hint=-1):
         lib.RowColumnNamesArrayPtr column_names = NULL
         np.uint32_t n_columns = 0
         lib.Exception exc = NULL
-        lib.SessionPtr session = lib.init_session()
 
     cdef lib.RowIteratorPtr row_iterator = lib.read_sql(
         <char*>stmt_bytes, db.db_ptr, &exc
@@ -43,7 +42,6 @@ cpdef dict read_sql(str stmt, Database db, int n_rows=-1, int size_hint=-1):
         &row_data_array_ptr,
         &n_columns,
         &column_names,
-        &session,
         &exc
     )
     if exc != NULL:
@@ -99,7 +97,6 @@ cpdef dict read_sql(str stmt, Database db, int n_rows=-1, int size_hint=-1):
                 &row_data_array_ptr,
                 &n_columns,
                 &column_names,
-                &session,
                 &exc
             )
             if exc != NULL:
@@ -109,7 +106,6 @@ cpdef dict read_sql(str stmt, Database db, int n_rows=-1, int size_hint=-1):
     if _n_rows == -1 and current_array_len != row_idx:
         for i in range(0, n_columns):
             resize(output[i], row_idx)
-    lib.free_session(session)
     return {columns[i]: output[i] for i in range(n_columns)}
 
 cdef int resize(np.ndarray arr, int len) except -1:
@@ -168,62 +164,56 @@ cdef np.ndarray insert_data_into_array(lib.Data data, np.ndarray arr, int idx):
     cdef:
         np.ndarray[np.uint8_t, ndim=1] arr_bytes
         np.npy_intp intp
-        lib.DateInfo date_
-        lib.DateTimeInfo datetime_
-        lib.TimeInfo time_
 
     if data.tag == lib.Data_Tag.Boolean:
-        arr[idx] = deref(data.boolean._0)
+        arr[idx] = data.boolean._0
 
     elif data.tag == lib.Data_Tag.Bytes:
-        arr[idx] = deref(data.bytes._0).ptr[:deref(data.bytes._0).len]
+        arr[idx] = data.bytes._0.ptr[:data.bytes._0.len]
         free(data.bytes._0.ptr)
 
     elif data.tag == lib.Data_Tag.Int8:
-        arr[idx] = deref(data.int8._0)
+        arr[idx] = data.int8._0
 
     elif data.tag == lib.Data_Tag.Int16:
-        arr[idx] = deref(data.int16._0)
+        arr[idx] = data.int16._0
 
     elif data.tag == lib.Data_Tag.Uint32:
-        arr[idx] = deref(data.uint32._0)
+        arr[idx] = data.uint32._0
 
     elif data.tag == lib.Data_Tag.Int64:
-        arr[idx] = deref(data.int64._0)
+        arr[idx] = data.int64._0
 
     elif data.tag == lib.Data_Tag.Int32:
-        arr[idx] = deref(data.int32._0)
+        arr[idx] = data.int32._0
 
     elif data.tag == lib.Data_Tag.Float64:
-        arr[idx] = deref(data.float64._0)
+        arr[idx] = data.float64._0
 
     elif data.tag == lib.Data_Tag.Float32:
-        arr[idx] = deref(data.float32._0)
+        arr[idx] = data.float32._0
 
     elif data.tag == lib.Data_Tag.String:
-        arr[idx] = PyUnicode_InternFromString(<char*>deref(data.string._0).ptr)
-        free(deref(data.string._0).ptr)
+        arr[idx] = PyUnicode_InternFromString(<char*>data.string._0.ptr)
+        free(data.string._0.ptr)
 
     elif data.tag == lib.Data_Tag.Date:
-        date_ = deref(data.date._0)
-        arr[idx] = DATE_01_JAN_2000 + np.timedelta64(date_.offset, 'D')
+        arr[idx] = DATE_01_JAN_2000 + np.timedelta64(data.date._0.offset, 'D')
 
     elif data.tag == lib.Data_Tag.DateTime:
-        datetime_ = deref(data.date_time._0)
-        arr[idx] = DATETIME_MID_NIGHT_01_JAN_2000 + np.timedelta64(datetime_.offset, 'us')
+        arr[idx] = DATETIME_MID_NIGHT_01_JAN_2000 + np.timedelta64(data.date_time._0.offset, 'us')
 
     elif data.tag == lib.Data_Tag.Time:
-        time_ = deref(data.time._0)
         arr[idx] = dt.time_new(
-            time_.hour,
-            time_.minute,
-            time_.second,
-            time_.usecond,
+            data.time._0.hour,
+            data.time._0.minute,
+            data.time._0.second,
+            data.time._0.usecond,
             None
         )
 
     elif data.tag == lib.Data_Tag.Decimal:
-        arr[idx] = deref(data.decimal._0)
+        arr[idx] = data.decimal._0
 
     elif data.tag == lib.Data_Tag.Null:
         if arr.dtype != object:

--- a/flaco/io.pyx
+++ b/flaco/io.pyx
@@ -18,8 +18,8 @@ cdef extern from "Python.h":
 
 
 cdef:
-    DATE_01_JAN_2000 = np.datetime64('2000-01-01', 'D')
-    DATETIME_MID_NIGHT_01_JAN_2000 = np.datetime64('2000-01-01T00:00:00', 'us')
+    np.int64_t DATE_01_JAN_2000 = np.datetime64('2000-01-01', 'D').astype(np.int64)
+    np.int64_t DATETIME_MID_NIGHT_01_JAN_2000 = np.datetime64('2000-01-01T00:00:00', 'us').astype(np.int64)
 
 cpdef dict read_sql(str stmt, Database db, int n_rows=-1, int size_hint=-1):
     cdef:
@@ -198,10 +198,16 @@ cdef np.ndarray insert_data_into_array(lib.Data data, np.ndarray arr, int idx):
         free(data.string._0.ptr)
 
     elif data.tag == lib.Data_Tag.Date:
-        arr[idx] = DATE_01_JAN_2000 + np.timedelta64(data.date._0.offset, 'D')
+        arr[idx] = np.timedelta64(
+            DATE_01_JAN_2000 + data.date._0.offset,
+            'D'
+        )
 
     elif data.tag == lib.Data_Tag.DateTime:
-        arr[idx] = DATETIME_MID_NIGHT_01_JAN_2000 + np.timedelta64(data.date_time._0.offset, 'us')
+        arr[idx] = np.timedelta64(
+            DATETIME_MID_NIGHT_01_JAN_2000 + data.date_time._0.offset,
+            'us'
+        )
 
     elif data.tag == lib.Data_Tag.Time:
         arr[idx] = dt.time_new(

--- a/flaco/io.pyx
+++ b/flaco/io.pyx
@@ -167,6 +167,11 @@ cdef np.ndarray insert_data_into_array(lib.Data data, np.ndarray arr, int idx):
     cdef np.npy_intp intp
     cdef dt.timedelta delta
     cdef object tzinfo
+    cdef:
+        lib.DateInfo date_
+        lib.DateTimeInfo datetime_
+        lib.DateTimeTzInfo datetimetz_
+        lib.TimeInfo time_
 
     if data.tag == lib.Data_Tag.Boolean:
         arr[idx] = deref(data.boolean._0)
@@ -201,51 +206,55 @@ cdef np.ndarray insert_data_into_array(lib.Data data, np.ndarray arr, int idx):
         free(deref(data.string._0).ptr)
 
     elif data.tag == lib.Data_Tag.Date:
+        date_ = deref(data.date._0)
         arr[idx] = dt.date_new(
-            deref(data.date._0).year,
-            deref(data.date._0).month,
-            deref(data.date._0).day
+            date_.year,
+            date_.month,
+            date_.day
         )
 
     elif data.tag == lib.Data_Tag.DateTime:
+        datetime_ = deref(data.date_time._0)
         arr[idx] = dt.datetime_new(
-            deref(data.date_time._0).date.year,
-            deref(data.date_time._0).date.month,
-            deref(data.date_time._0).date.day,
-            deref(data.date_time._0).time.hour,
-            deref(data.date_time._0).time.minute,
-            deref(data.date_time._0).time.second,
-            deref(data.date_time._0).time.usecond,
+            datetime_.date.year,
+            datetime_.date.month,
+            datetime_.date.day,
+            datetime_.time.hour,
+            datetime_.time.minute,
+            datetime_.time.second,
+            datetime_.time.usecond,
             None
         )
 
     elif data.tag == lib.Data_Tag.DateTimeTz:
+        datetimetz_ = deref(data.date_time_tz._0)
         delta = dt.timedelta_new(
-            deref(data.date_time_tz._0).tz.hours,
-            deref(data.date_time_tz._0).tz.minutes,
-            deref(data.date_time_tz._0).tz.seconds
+            datetimetz_.tz.hours,
+            datetimetz_.tz.minutes,
+            datetimetz_.tz.seconds
         )
         if data.date_time_tz._0.tz.is_positive:
             tzinfo = dt.timezone(delta)
         else:
             tzinfo = dt.timezone(-delta)
         arr[idx] = dt.datetime_new(
-            deref(data.date_time_tz._0).date.year,
-            deref(data.date_time_tz._0).date.month,
-            deref(data.date_time_tz._0).date.day,
-            deref(data.date_time_tz._0).time.hour,
-            deref(data.date_time_tz._0).time.minute,
-            deref(data.date_time_tz._0).time.second,
-            deref(data.date_time_tz._0).time.usecond,
+            datetimetz_.date.year,
+            datetimetz_.date.month,
+            datetimetz_.date.day,
+            datetimetz_.time.hour,
+            datetimetz_.time.minute,
+            datetimetz_.time.second,
+            datetimetz_.time.usecond,
             tzinfo
         )
 
     elif data.tag == lib.Data_Tag.Time:
+        time_ = deref(data.time._0)
         arr[idx] = dt.time_new(
-            deref(data.time._0).hour,
-            deref(data.time._0).minute,
-            deref(data.time._0).second,
-            deref(data.time._0).usecond,
+            time_.hour,
+            time_.minute,
+            time_.second,
+            time_.usecond,
             None
         )
 


### PR DESCRIPTION
Use direct i64 values from postgres_protocol and calculate into `numpy.datetime64` types.
Greatly improves memory, but costs more time. (still ~3x faster than pandas, but slower than connectorx now)