### PR TITLE
Improve temporal types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "flaco"
-version = "0.6.0-rc2"
+version = "0.6.0-rc3"
 edition = "2018"
 license = "Unlicense/MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde_json   = "^1"
 numpy        = "0.17"
 arrow2       = { version = "^0.13", features = ["io_ipc", "io_parquet"] }
 rust_decimal = { version = "1.16.0", features = ["db-postgres"] }
-time         = { version = "0.3.3",  features = ["formatting"] }
+time         = { version = "0.3.3",  features = ["formatting", "parsing"] }
 postgres     = { version = "0.19.1", features = ["with-time-0_3", "with-serde_json-1", "with-uuid-0_8"] }
 postgres-protocol = "0.6.2"
 pyo3         = { version = "0.17", default-features = false, features = ["macros"] }

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -118,8 +118,6 @@ def _table_setup(n_rows: int = 1_000_000, include_nulls: bool = False):
 def memory_profile():
     stmt = "select * from test_table"
     flaco.read_sql_to_file(DB_URI, stmt, 'result.feather', flaco.FileFormat.Feather)
-    data = flaco.read_sql_to_numpy(DB_URI, stmt)
-    df = pd.DataFrame(data, copy=False).convert_dtypes()
     import duckdb
     import pyarrow as pa
     import pyarrow.parquet as pq
@@ -127,15 +125,12 @@ def memory_profile():
     import pyarrow.dataset as ds
     with pa.memory_map('result.feather', 'rb') as source:
         mytable = pa.ipc.open_file(source).read_all()
-        table = mytable.rename_columns([f"col_{i}" for i in range(10)])
-        table_df = table.to_pandas()
+        table_df = mytable.to_pandas()
         #print(v)
-        print(type(mytable), len(mytable))
-        print(type(table), len(table))
         print(pa.total_allocated_bytes() >> 20)
-    breakpoint()
     engine = create_engine(DB_URI)
     _pandas_df = pd.read_sql(stmt, engine)
+    breakpoint()
 
 
 if __name__ == "__main__":

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -106,7 +106,7 @@ def _table_setup(n_rows: int = 1_000_000, include_nulls: bool = False):
     df["col8"] = pd.to_datetime(df.col7)
     df["col9"] = pd.to_datetime(df.col7, utc=True)
     df["col10"] = df.col9.dt.time
-    df.to_sql(table, index=False, con=engine, chunksize=10_000, if_exists="append")
+    df.to_sql(table, index=False, con=engine, chunksize=50_000, if_exists="replace")
 
     if include_nulls:
         df = df[:20]
@@ -130,9 +130,8 @@ def memory_profile():
         print(pa.total_allocated_bytes() >> 20)
     engine = create_engine(DB_URI)
     _pandas_df = pd.read_sql(stmt, engine)
-    breakpoint()
 
 
 if __name__ == "__main__":
-    _table_setup(n_rows=10_000, include_nulls=False)
+    #_table_setup(n_rows=1_000_000, include_nulls=False)
     memory_profile()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,10 +277,7 @@ pub mod postgresql {
                         })
                         .push::<_, MutablePrimitiveArray<i32>>(
                             row.get::<_, Option<time::Date>>(idx).map(|v| {
-                                let format =
-                                    time::format_description::parse("[year]-[month]-[day]")
-                                        .unwrap();
-                                let base = time::Date::parse("1970-01-01", &format).unwrap();
+                                let base = time::OffsetDateTime::UNIX_EPOCH.date();
                                 let days = (base - v).whole_days() as i32;
                                 if v > base {
                                     days.abs()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,6 @@ pub mod postgresql {
                         )?;
                 }
                 &Type::TIMESTAMPTZ => {
-                    // TODO: If first row is null, the TimeStamp will not actually have a TZ. :S
                     let value = row.get::<_, Option<time::OffsetDateTime>>(idx);
                     let format =
                         format_description::parse("[offset_hour sign:mandatory]:[offset_minute]")
@@ -280,6 +279,11 @@ pub mod postgresql {
                     table
                         .entry(column_name)
                         .or_insert_with(|| {
+                            if value.is_none() {
+                                unimplemented!(
+                                    "Handle case where first row of TZ aware timestamp is null."
+                                )
+                            }
                             Column::new(MutablePrimitiveArray::<i64>::new().to(
                                 DataType::Timestamp(
                                     TimeUnit::Microsecond,


### PR DESCRIPTION
Remove all use of Utf8Array when handling temporal types, in favor or proper `DataType::Timestamp` and the like.

This also removes `read_sql_to_numpy` as I don't think that's a worthy compatibility to keep.